### PR TITLE
perf: fix message-timeline scroll jitter and reduce main-actor churn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ xcuserdata/
 *.mobileprovision
 Package.resolved
 !App/Package.resolved
+*.trace

--- a/App/Sources/SakuraCord/Models/AppModel.swift
+++ b/App/Sources/SakuraCord/Models/AppModel.swift
@@ -375,9 +375,11 @@ final class AppModel {
     private(set) var selectedChannel: Channel?
     private(set) var messages: [Message] = [] {
         didSet {
-            messageRows = MessageGrouping.updating(
-                existing: messageRows, oldMessages: oldValue, newMessages: messages
-            )
+            messageRows = MainActorWorkDiagnostics.measure(.messageRows) {
+                MessageGrouping.updating(
+                    existing: messageRows, oldMessages: oldValue, newMessages: messages
+                )
+            }
             indexMessageAuthors(in: messages, resettingWhenEmpty: true)
             if let selectedChannelID {
                 messageCache[selectedChannelID] = messages
@@ -432,7 +434,9 @@ final class AppModel {
         if let memberSectionCache {
             return memberSectionCache
         }
-        let value = MemberSection.make(from: members)
+        let value = MainActorWorkDiagnostics.measure(.memberSections) {
+            MemberSection.make(from: members)
+        }
         memberSectionCache = value
         return value
     }
@@ -654,9 +658,12 @@ final class AppModel {
     }
 
     private func updateHiddenChannelIDs() {
-        var value: Set<ChannelID> = []
-        for channel in visibleChannels where conversationAccess(for: channel) == .hidden {
-            value.insert(channel.id)
+        let value = MainActorWorkDiagnostics.measure(.hiddenChannels) {
+            var value: Set<ChannelID> = []
+            for channel in visibleChannels where conversationAccess(for: channel) == .hidden {
+                value.insert(channel.id)
+            }
+            return value
         }
         guard hiddenChannelIDs != value else { return }
         hiddenChannelIDs = value
@@ -1003,7 +1010,7 @@ final class AppModel {
         eventTask = Task { [weak self] in
             for await event in stream {
                 guard !Task.isCancelled else { break }
-                self?.consume(event)
+                MainActorWorkDiagnostics.measure(.gatewayEvent) { self?.consume(event) }
             }
         }
         isLoading = true
@@ -3215,14 +3222,17 @@ final class AppModel {
     /// Scoped to conversation authors rather than the whole guild so a large
     /// member list does not make this proportional to guild size.
     private func updateAuthorPresentations() {
-        var value: [UserID: MessageAuthorPresentation] = [:]
-        value.reserveCapacity(messageAuthorsByID.count)
-        for userID in messageAuthorsByID.keys {
-            guard let member = membersByID[userID] else { continue }
-            value[userID] = MessageAuthorPresentation(
-                user: member.user,
-                roleColorHex: MessageAuthorPresentation.topRoleColor(in: member.roles)
-            )
+        let value = MainActorWorkDiagnostics.measure(.authorPresentations) {
+            var value: [UserID: MessageAuthorPresentation] = [:]
+            value.reserveCapacity(messageAuthorsByID.count)
+            for userID in messageAuthorsByID.keys {
+                guard let member = membersByID[userID] else { continue }
+                value[userID] = MessageAuthorPresentation(
+                    user: member.user,
+                    roleColorHex: MessageAuthorPresentation.topRoleColor(in: member.roles)
+                )
+            }
+            return value
         }
         guard authorPresentationsByUserID != value else { return }
         authorPresentationsByUserID = value

--- a/App/Sources/SakuraCord/Models/AppModel.swift
+++ b/App/Sources/SakuraCord/Models/AppModel.swift
@@ -321,6 +321,10 @@ final class AppModel {
         category: "PointsOfInterest"
     )
     nonisolated static let maximumConcurrentReactionReactorLoads = 4
+    /// Discord emits a full member list for every presence change in the active
+    /// guild. Applying each one separately re-derives member sections, indexes,
+    /// and every view that reads them, so bursts are collapsed into one update.
+    nonisolated static let memberUpdateCoalescingInterval: Duration = .milliseconds(100)
 
     enum SessionState: Equatable {
         case restoring
@@ -334,29 +338,61 @@ final class AppModel {
         var throttle: Duration = .seconds(8)
     }
 
-    private(set) var snapshot: BootstrapSnapshot?
+    private(set) var snapshot: BootstrapSnapshot? {
+        didSet {
+            guard snapshot?.channels != oldValue?.channels else { return }
+            channelsByID = Dictionary(
+                (snapshot?.channels ?? []).map { ($0.id, $0) },
+                uniquingKeysWith: { _, newer in newer }
+            )
+        }
+    }
+
+    /// Mention and navigation lookups resolve channels per render. Snapshots
+    /// carry every channel of every guild, so those must not be linear scans.
+    private(set) var channelsByID: [ChannelID: Channel] = [:]
     private(set) var serverRailGuildsByID: [GuildID: Guild] = [:]
     private(set) var serverRailItems: [GuildRailItem] = [] {
         didSet { updateOrderedCustomEmojis() }
     }
-    private(set) var visibleChannels: [Channel] = []
+    private(set) var visibleChannels: [Channel] = [] {
+        didSet {
+            guard visibleChannels != oldValue else { return }
+            updateHiddenChannelIDs()
+        }
+    }
+
+    /// Channels the current user cannot read.
+    ///
+    /// The sidebar previously derived this in its body, so every render
+    /// re-resolved permissions for every channel — and because that reads the
+    /// member store, presence traffic drove it.
+    private(set) var hiddenChannelIDs: Set<ChannelID> = []
+    @ObservationIgnored private var currentMemberRoleIDs: [RoleID] = []
     private(set) var selectedChannel: Channel?
     private(set) var messages: [Message] = [] {
         didSet {
             messageRows = MessageGrouping.updating(
                 existing: messageRows, oldMessages: oldValue, newMessages: messages
             )
+            indexMessageAuthors(in: messages, resettingWhenEmpty: true)
             if let selectedChannelID {
                 messageCache[selectedChannelID] = messages
             }
         }
     }
 
+    /// Authors seen in the loaded conversation, so mention resolution can fall
+    /// back to them without scanning the timeline on every render.
+    private(set) var messageAuthorsByID: [UserID: User] = [:]
+
     private(set) var messageRows: [MessageRowPresentation] = []
     private(set) var messageNavigationRequest: MessageNavigationRequest?
     private(set) var members: [Member] = [] {
         didSet {
-            memberSections = MemberSection.make(from: members)
+            // Sectioning is only read while the inspector is on screen, so it
+            // is derived on demand instead of on every Gateway member update.
+            memberSectionCache = nil
             let indexed = Dictionary(
                 members.map { ($0.id, $0) },
                 uniquingKeysWith: { _, newer in newer }
@@ -367,9 +403,48 @@ final class AppModel {
         }
     }
 
-    private(set) var membersByID: [UserID: Member] = [:]
-    private(set) var memberSections: [MemberSection] = []
-    private(set) var guildRoles: [GuildRole] = []
+    private(set) var membersByID: [UserID: Member] = [:] {
+        didSet {
+            updateAuthorPresentations()
+            // Channel visibility only moves when the current user's own roles
+            // move, not when some other member's presence changes.
+            let currentUserID = snapshot?.currentUser.id
+            let roleIDs = currentUserID.flatMap { membersByID[$0]?.roles.map(\.id) } ?? []
+            guard roleIDs != currentMemberRoleIDs else { return }
+            currentMemberRoleIDs = roleIDs
+            updateHiddenChannelIDs()
+        }
+    }
+
+    /// Author display values for everyone in the loaded conversation.
+    ///
+    /// A presence change mutates `membersByID` but cannot change any of these
+    /// values, so deriving them here — and assigning only on a real difference —
+    /// keeps presence traffic from invalidating the timeline.
+    private(set) var authorPresentationsByUserID: [UserID: MessageAuthorPresentation] = [:]
+    @ObservationIgnored private var memberSectionCache: [MemberSection]?
+
+    var memberSections: [MemberSection] {
+        if let memberSectionCache {
+            return memberSectionCache
+        }
+        let value = MemberSection.make(from: members)
+        memberSectionCache = value
+        return value
+    }
+    private(set) var guildRoles: [GuildRole] = [] {
+        didSet {
+            guard guildRoles != oldValue else { return }
+            guildRolesByID = Dictionary(
+                guildRoles.map { ($0.id, $0) },
+                uniquingKeysWith: { _, newer in newer }
+            )
+            updateAuthorPresentations()
+            updateHiddenChannelIDs()
+        }
+    }
+
+    private(set) var guildRolesByID: [RoleID: GuildRole] = [:]
     private(set) var commandMemberResults: [Member] = []
     private(set) var mentionMemberResults: [Member] = []
     private(set) var mentionAutocompleteMembers: [Member] = []
@@ -425,6 +500,7 @@ final class AppModel {
                 oldMessages: oldValue,
                 newMessages: threadMessages
             )
+            indexMessageAuthors(in: threadMessages, resettingWhenEmpty: false)
         }
     }
     private(set) var threadMessageRows: [MessageRowPresentation] = []
@@ -573,6 +649,15 @@ final class AppModel {
         )
     }
 
+    private func updateHiddenChannelIDs() {
+        var value: Set<ChannelID> = []
+        for channel in visibleChannels where conversationAccess(for: channel) == .hidden {
+            value.insert(channel.id)
+        }
+        guard hiddenChannelIDs != value else { return }
+        hiddenChannelIDs = value
+    }
+
     func conversationAccess(for channel: Channel) -> ConversationAccess {
         guard let guildID = channel.guildID else { return .readable(canSend: true) }
         guard let guild = serverRailGuildsByID[guildID],
@@ -672,6 +757,8 @@ final class AppModel {
     @ObservationIgnored private var mentionMemberSearchCache:
         [CommandMemberQuery: MentionMemberSearchCacheEntry] = [:]
     @ObservationIgnored private var roleMemberTask: Task<Void, Never>?
+    @ObservationIgnored private var pendingMemberUpdate: (guildID: GuildID, members: [Member])?
+    @ObservationIgnored private var memberUpdateTask: Task<Void, Never>?
     @ObservationIgnored private var commandExecutionTask: Task<Void, Never>?
     @ObservationIgnored private var stickerLoadTasks: [GuildID: Task<Void, Never>] = [:]
     @ObservationIgnored private var componentKeyByNonce: [String: ComponentControlKey] = [:]
@@ -864,6 +951,7 @@ final class AppModel {
         messages = []
         messageCache = [:]
         hasMoreCache = [:]
+        cancelPendingMemberUpdate()
         members = []
         dismissProfile()
         connectionState = .disconnected
@@ -1225,7 +1313,56 @@ final class AppModel {
         )
     }
 
+    /// Collapses a burst of Gateway member updates into a single applied value.
+    private func scheduleMemberUpdate(guildID: GuildID, members value: [Member]) {
+        pendingMemberUpdate = (guildID, value)
+        guard memberUpdateTask == nil else { return }
+        memberUpdateTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: Self.memberUpdateCoalescingInterval)
+            guard let self else { return }
+            memberUpdateTask = nil
+            guard let pending = pendingMemberUpdate else { return }
+            pendingMemberUpdate = nil
+            guard pending.guildID == selectedGuildID else { return }
+            applyMemberUpdate(pending.members)
+        }
+    }
+
+    private func cancelPendingMemberUpdate() {
+        memberUpdateTask?.cancel()
+        memberUpdateTask = nil
+        pendingMemberUpdate = nil
+    }
+
+    private func applyMemberUpdate(_ value: [Member]) {
+        guard members != value else { return }
+        members = value
+        if mentionAutocompleteMembers.isEmpty {
+            // A guild activation can finish before Discord's lazy member
+            // list has delivered its first store snapshot. Seed the
+            // dedicated autocomplete store from that first Gateway update
+            // instead of leaving every nonempty @ query blank.
+            mentionAutocompleteMembers = value
+        } else {
+            // Refresh already-known values (nickname/avatar/roles) without
+            // letting later visual member-list sorting reorder or expand
+            // the autocomplete store.
+            let updatesByID = Dictionary(
+                value.map { ($0.id, $0) },
+                uniquingKeysWith: { _, newer in newer }
+            )
+            let refreshed = mentionAutocompleteMembers.map { updatesByID[$0.id] ?? $0 }
+            if refreshed != mentionAutocompleteMembers {
+                mentionAutocompleteMembers = refreshed
+            }
+        }
+        if let selectedMember, let updated = value.first(where: { $0.id == selectedMember.id }) {
+            self.selectedMember = updated
+        }
+    }
+
     private func beginMemberLoad(for guildID: GuildID?) {
+        cancelPendingMemberUpdate()
         memberLoadTask?.cancel()
         memberLoadTask = Task { [weak self] in
             guard let self else { return }
@@ -3011,10 +3148,62 @@ final class AppModel {
         presentProfile(for: member)
     }
 
+    /// Accumulates conversation authors. Writes only land when a new author
+    /// appears, so an ordinary incoming message does not invalidate readers.
+    private func indexMessageAuthors(in values: [Message], resettingWhenEmpty: Bool) {
+        if values.isEmpty, resettingWhenEmpty {
+            if !messageAuthorsByID.isEmpty {
+                messageAuthorsByID = [:]
+                updateAuthorPresentations()
+            }
+            return
+        }
+        var additions: [UserID: User] = [:]
+        for message in values where messageAuthorsByID[message.author.id] == nil {
+            additions[message.author.id] = message.author
+        }
+        guard !additions.isEmpty else { return }
+        messageAuthorsByID.merge(additions) { _, newer in newer }
+        updateAuthorPresentations()
+    }
+
+    func forumPost(withID channelID: ChannelID) -> ForumPost? {
+        if let index = forumCatalogueIndexByID[channelID],
+           forumCataloguePosts.indices.contains(index)
+        {
+            return forumCataloguePosts[index]
+        }
+        return forumPosts.first { $0.id == channelID }
+    }
+
+    /// Rebuilds presentations for authors present in the loaded conversation.
+    ///
+    /// Scoped to conversation authors rather than the whole guild so a large
+    /// member list does not make this proportional to guild size.
+    private func updateAuthorPresentations() {
+        var value: [UserID: MessageAuthorPresentation] = [:]
+        value.reserveCapacity(messageAuthorsByID.count)
+        for userID in messageAuthorsByID.keys {
+            guard let member = membersByID[userID] else { continue }
+            value[userID] = MessageAuthorPresentation(
+                user: member.user,
+                roleColorHex: MessageAuthorPresentation.topRoleColor(in: member.roles)
+            )
+        }
+        guard authorPresentationsByUserID != value else { return }
+        authorPresentationsByUserID = value
+    }
+
     func authorPresentation(for message: Message) -> MessageAuthorPresentation {
-        MessageAuthorPresentation.resolve(
+        if let value = authorPresentationsByUserID[message.author.id] {
+            return value
+        }
+        // Authors outside the member store (webhooks, apps, departed members)
+        // resolve from the message itself. `guildRoles` changes on guild switch
+        // rather than on presence traffic, so reading it here is not hot.
+        return MessageAuthorPresentation.resolve(
             message: message,
-            member: membersByID[message.author.id],
+            member: nil,
             roles: guildRoles
         )
     }
@@ -3212,28 +3401,7 @@ final class AppModel {
             hasMoreForumPosts = page.hasMore
         case .membersChanged(let guildID, let value):
             guard guildID == selectedGuildID else { return }
-            members = value
-            if mentionAutocompleteMembers.isEmpty {
-                // A guild activation can finish before Discord's lazy member
-                // list has delivered its first store snapshot. Seed the
-                // dedicated autocomplete store from that first Gateway update
-                // instead of leaving every nonempty @ query blank.
-                mentionAutocompleteMembers = value
-            } else {
-                // Refresh already-known values (nickname/avatar/roles) without
-                // letting later visual member-list sorting reorder or expand
-                // the autocomplete store.
-                let updatesByID = Dictionary(
-                    value.map { ($0.id, $0) },
-                    uniquingKeysWith: { _, newer in newer }
-                )
-                mentionAutocompleteMembers = mentionAutocompleteMembers.map {
-                    updatesByID[$0.id] ?? $0
-                }
-            }
-            if let selectedMember, let updated = value.first(where: { $0.id == selectedMember.id }) {
-                self.selectedMember = updated
-            }
+            scheduleMemberUpdate(guildID: guildID, members: value)
         case .voiceStateChanged(let state):
             if state.channelID == nil {
                 voiceStates[state.userID] = nil

--- a/App/Sources/SakuraCord/Models/AppModel.swift
+++ b/App/Sources/SakuraCord/Models/AppModel.swift
@@ -326,6 +326,9 @@ final class AppModel {
     /// and every view that reads them, so bursts are collapsed into one update.
     nonisolated static let memberUpdateCoalescingInterval: Duration = .milliseconds(100)
 
+    /// How many channels keep their loaded history in memory between visits.
+    nonisolated static let cachedChannelHistoryLimit = 12
+
     enum SessionState: Equatable {
         case restoring
         case signedOut
@@ -378,6 +381,7 @@ final class AppModel {
             indexMessageAuthors(in: messages, resettingWhenEmpty: true)
             if let selectedChannelID {
                 messageCache[selectedChannelID] = messages
+                retainMessageCache(for: selectedChannelID)
             }
         }
     }
@@ -777,6 +781,9 @@ final class AppModel {
     @ObservationIgnored private var messageNavigationRequestID: UInt64 = 0
     @ObservationIgnored private var messageCache: [ChannelID: [Message]] = [:]
     @ObservationIgnored private var hasMoreCache: [ChannelID: Bool] = [:]
+    /// Least-recently-selected first. Bounds `messageCache`, which otherwise
+    /// retains every channel visited for the whole session.
+    @ObservationIgnored private var messageCacheOrder: [ChannelID] = []
     @ObservationIgnored private let discordNetworkDisabled: Bool
     @ObservationIgnored private let restoresStoredSession: Bool
     @ObservationIgnored private let credentialStore: any CredentialStore
@@ -896,6 +903,7 @@ final class AppModel {
         messages = []
         messageCache = [:]
         hasMoreCache = [:]
+        messageCacheOrder = []
         dismissProfile()
         errorMessage = nil
         await start(publishesSessionState: !preservesInteractivePresentation)
@@ -951,6 +959,7 @@ final class AppModel {
         messages = []
         messageCache = [:]
         hasMoreCache = [:]
+        messageCacheOrder = []
         cancelPendingMemberUpdate()
         members = []
         dismissProfile()
@@ -3165,6 +3174,31 @@ final class AppModel {
         guard !additions.isEmpty else { return }
         messageAuthorsByID.merge(additions) { _, newer in newer }
         updateAuthorPresentations()
+    }
+
+    /// Marks a channel as most recently used and drops the oldest beyond the
+    /// limit. Eviction only costs a reload on revisit, which is the same path a
+    /// first visit already takes; `hasMoreCache` goes with it so the two can
+    /// never disagree about how much history is available.
+    private func retainMessageCache(for channelID: ChannelID) {
+        if let index = messageCacheOrder.firstIndex(of: channelID) {
+            messageCacheOrder.remove(at: index)
+        }
+        messageCacheOrder.append(channelID)
+
+        var excess = messageCacheOrder.count - Self.cachedChannelHistoryLimit
+        var index = 0
+        while excess > 0, index < messageCacheOrder.count {
+            let candidate = messageCacheOrder[index]
+            guard candidate != selectedChannelID else {
+                index += 1
+                continue
+            }
+            messageCache[candidate] = nil
+            hasMoreCache[candidate] = nil
+            messageCacheOrder.remove(at: index)
+            excess -= 1
+        }
     }
 
     func forumPost(withID channelID: ChannelID) -> ForumPost? {

--- a/App/Sources/SakuraCord/Support/MainActorWorkDiagnostics.swift
+++ b/App/Sources/SakuraCord/Support/MainActorWorkDiagnostics.swift
@@ -1,0 +1,139 @@
+import Foundation
+import OSLog
+
+/// Opt-in timing for the state derivations that run on the main actor.
+///
+/// The app target is `defaultIsolation(MainActor.self)`, so every `didSet`
+/// cascade in `AppModel` is frame time by construction. Before moving any of it
+/// off the main actor, this says which pieces actually cost anything: an
+/// Instruments Points of Interest interval plus a periodic summary of count,
+/// total, and worst case per stage.
+///
+/// Shares `--scroll-diagnostics`, so ordinary and packaged runs pay nothing.
+/// Records durations only — no message, member, or channel value is logged.
+@MainActor
+enum MainActorWorkDiagnostics {
+    enum Stage: CaseIterable {
+        case memberSections
+        case hiddenChannels
+        case messageRows
+        case authorPresentations
+        case gatewayEvent
+
+        var label: String {
+            switch self {
+            case .memberSections: "memberSections"
+            case .hiddenChannels: "hiddenChannels"
+            case .messageRows: "messageRows"
+            case .authorPresentations: "authorPresentations"
+            case .gatewayEvent: "gatewayEvent"
+            }
+        }
+
+        /// Signpost names must be static, so they cannot come from `label`.
+        var signpostName: StaticString {
+            switch self {
+            case .memberSections: "memberSections"
+            case .hiddenChannels: "hiddenChannels"
+            case .messageRows: "messageRows"
+            case .authorPresentations: "authorPresentations"
+            case .gatewayEvent: "gatewayEvent"
+            }
+        }
+    }
+
+    private struct Tally {
+        var count = 0
+        var totalMilliseconds = 0.0
+        var worstMilliseconds = 0.0
+    }
+
+    static let isEnabled = ScrollDiagnostics.isEnabled
+
+    /// One frame at 60Hz. Anything reliably under this is not worth moving.
+    static let frameBudgetMilliseconds = 16.7
+
+    private static let logger = Logger(
+        subsystem: "dev.sakuracord.SakuraCord",
+        category: "MainActorWork"
+    )
+    private static let signposter = OSSignposter(
+        subsystem: "dev.sakuracord.SakuraCord",
+        category: "PointsOfInterest"
+    )
+
+    private static var tallies: [Stage: Tally] = [:]
+    private static var windowStartedAt: ContinuousClock.Instant?
+    private static let reportingInterval: Duration = .seconds(5)
+
+    /// Times `work` and reports it. Returns `work`'s value untouched, so call
+    /// sites read the same as they did before.
+    static func measure<T>(_ stage: Stage, _ work: () throws -> T) rethrows -> T {
+        guard isEnabled else { return try work() }
+        let startedAt = ContinuousClock.now
+        let interval = signposter.beginInterval(stage.signpostName)
+        defer {
+            signposter.endInterval(stage.signpostName, interval)
+            record(stage, elapsed: startedAt.duration(to: .now))
+        }
+        return try work()
+    }
+
+    private static func record(_ stage: Stage, elapsed: Duration) {
+        let milliseconds = Self.milliseconds(elapsed)
+        var tally = tallies[stage] ?? Tally()
+        tally.count += 1
+        tally.totalMilliseconds += milliseconds
+        tally.worstMilliseconds = max(tally.worstMilliseconds, milliseconds)
+        tallies[stage] = tally
+
+        guard let windowStartedAt else {
+            self.windowStartedAt = ContinuousClock.now
+            return
+        }
+        let windowElapsed = windowStartedAt.duration(to: .now)
+        guard windowElapsed >= reportingInterval else { return }
+        report(over: windowElapsed)
+    }
+
+    /// Reports whatever has accumulated without waiting for the interval.
+    ///
+    /// Reporting is otherwise driven from `record`, so a window that ends in
+    /// silence would never flush — and the interesting case is exactly that:
+    /// scroll, stop, read the numbers.
+    static func flush() {
+        guard isEnabled, let windowStartedAt else { return }
+        report(over: windowStartedAt.duration(to: .now))
+    }
+
+    private static func report(over windowElapsed: Duration) {
+        let summary = Stage.allCases.compactMap { stage -> String? in
+            guard let tally = tallies[stage], tally.count > 0 else { return nil }
+            return String(
+                format: "%@ n=%d total=%.1fms worst=%.2fms",
+                stage.label,
+                tally.count,
+                tally.totalMilliseconds,
+                tally.worstMilliseconds
+            )
+        }
+        tallies = [:]
+        windowStartedAt = ContinuousClock.now
+        guard !summary.isEmpty else { return }
+        let window = Self.milliseconds(windowElapsed) / 1000
+        // Stage labels and durations only, so redaction would hide the whole
+        // point of the line without protecting anything.
+        logger.info(
+            """
+            main-actor work over \(window, format: .fixed(precision: 1))s — \
+            \(summary.joined(separator: ", "), privacy: .public)
+            """
+        )
+    }
+
+    private static func milliseconds(_ duration: Duration) -> Double {
+        let components = duration.components
+        return Double(components.seconds) * 1000
+            + Double(components.attoseconds) / 1_000_000_000_000_000
+    }
+}

--- a/App/Sources/SakuraCord/Support/ScrollDiagnostics.swift
+++ b/App/Sources/SakuraCord/Support/ScrollDiagnostics.swift
@@ -1,0 +1,122 @@
+import Foundation
+import OSLog
+
+/// Opt-in scroll instrumentation for diagnosing timeline stutter.
+///
+/// Enabled only by `--scroll-diagnostics`, so ordinary and packaged runs pay
+/// nothing. Records counts rather than content: no message text, author, or
+/// channel value is ever logged.
+nonisolated struct ScrollDiagnosticsSample: Equatable {
+    let contentHeight: CGFloat
+    let contentOffset: CGFloat
+}
+
+@MainActor
+enum ScrollDiagnostics {
+    static let isEnabled = ProcessInfo.processInfo.arguments.contains("--scroll-diagnostics")
+
+    private static let logger = Logger(
+        subsystem: "dev.sakuracord.SakuraCord",
+        category: "ScrollDiagnostics"
+    )
+
+    private static var textViewsCreated = 0
+    private static var textViewsDismantled = 0
+    private static var attributedStringsBuilt = 0
+    private static var heightCacheHits = 0
+    private static var heightCacheMisses = 0
+    private static var contentHeightChanges = 0
+    private static var lastContentHeight: CGFloat?
+    private static var lastContentOffset: CGFloat?
+    private static var largestContentHeightJump: CGFloat = 0
+    private static var uncompensatedJumps = 0
+    private static var largestUncompensatedJump: CGFloat = 0
+    private static var windowStartedAt: Date?
+    /// The timeline realizes every loaded row, so this is the number that says
+    /// whether history growth has started to cost anything.
+    private static var rowCount = 0
+
+    static func recordTextViewCreated() {
+        guard isEnabled else { return }
+        textViewsCreated += 1
+    }
+
+    static func recordTextViewDismantled() {
+        guard isEnabled else { return }
+        textViewsDismantled += 1
+    }
+
+    static func recordAttributedStringBuilt() {
+        guard isEnabled else { return }
+        attributedStringsBuilt += 1
+    }
+
+    static func recordHeightCacheHit() {
+        guard isEnabled else { return }
+        heightCacheHits += 1
+    }
+
+    static func recordHeightCacheMiss() {
+        guard isEnabled else { return }
+        heightCacheMisses += 1
+    }
+
+    /// Content height changing mid-scroll only moves the visible content when
+    /// the scroll view fails to absorb it into the offset. Growth above the
+    /// viewport should shift `contentOffset` by the same amount; when it does
+    /// not, that difference is the visible jump.
+    static func recordGeometry(height: CGFloat, offset: CGFloat) {
+        guard isEnabled else { return }
+        defer {
+            lastContentHeight = height
+            lastContentOffset = offset
+        }
+        guard let previousHeight = lastContentHeight,
+              let previousOffset = lastContentOffset
+        else { return }
+        let heightDelta = height - previousHeight
+        guard abs(heightDelta) > 0.5 else { return }
+        contentHeightChanges += 1
+        largestContentHeightJump = max(largestContentHeightJump, abs(heightDelta))
+
+        let offsetDelta = offset - previousOffset
+        let uncompensated = abs(heightDelta - offsetDelta)
+        guard uncompensated > 1 else { return }
+        uncompensatedJumps += 1
+        largestUncompensatedJump = max(largestUncompensatedJump, uncompensated)
+    }
+
+    static func beginScroll(rowCount: Int) {
+        guard isEnabled, windowStartedAt == nil else { return }
+        windowStartedAt = Date()
+        self.rowCount = rowCount
+        textViewsCreated = 0
+        textViewsDismantled = 0
+        attributedStringsBuilt = 0
+        heightCacheHits = 0
+        heightCacheMisses = 0
+        contentHeightChanges = 0
+        largestContentHeightJump = 0
+        uncompensatedJumps = 0
+        largestUncompensatedJump = 0
+    }
+
+    static func endScroll() {
+        guard isEnabled, let startedAt = windowStartedAt else { return }
+        windowStartedAt = nil
+        let duration = Date().timeIntervalSince(startedAt)
+        logger.info(
+            """
+            scroll finished in \(duration, format: .fixed(precision: 2))s — \
+            rows=\(rowCount), \
+            textViews created=\(textViewsCreated) dismantled=\(textViewsDismantled), \
+            attributedStrings=\(attributedStringsBuilt), \
+            heightCache hits=\(heightCacheHits) misses=\(heightCacheMisses), \
+            contentHeightChanges=\(contentHeightChanges) \
+            largestJump=\(largestContentHeightJump, format: .fixed(precision: 1))pt, \
+            uncompensated=\(uncompensatedJumps) \
+            largestUncompensated=\(largestUncompensatedJump, format: .fixed(precision: 1))pt
+            """
+        )
+    }
+}

--- a/App/Sources/SakuraCord/Support/ScrollDiagnostics.swift
+++ b/App/Sources/SakuraCord/Support/ScrollDiagnostics.swift
@@ -104,6 +104,9 @@ enum ScrollDiagnostics {
     static func endScroll() {
         guard isEnabled, let startedAt = windowStartedAt else { return }
         windowStartedAt = nil
+        // The main-actor derivations are the other half of the picture, and a
+        // scroll that ends in silence would otherwise never report them.
+        MainActorWorkDiagnostics.flush()
         let duration = Date().timeIntervalSince(startedAt)
         logger.info(
             """

--- a/App/Sources/SakuraCord/Support/TextAttachmentSupport.swift
+++ b/App/Sources/SakuraCord/Support/TextAttachmentSupport.swift
@@ -96,6 +96,7 @@ final class InlineAttachmentImageLoader {
     func loadMentionAvatars(in textView: NSTextView) {
         let attributed = textView.attributedString()
         var values: [String: URL] = [:]
+        var pending: [String: URL] = [:]
         attributed.enumerateAttribute(
             .attachment,
             in: NSRange(location: 0, length: attributed.length)
@@ -103,17 +104,32 @@ final class InlineAttachmentImageLoader {
             guard let attachment = value as? MentionTextAttachment,
                   let url = attachment.presentation.avatarURL
             else { return }
-            values[attachment.presentation.rawToken] = url
+            let token = attachment.presentation.rawToken
+            values[token] = url
+            // Applying an avatar re-rasterizes both pill images and invalidates
+            // display, so skip attachments that already carry this one.
+            if attachment.appliedAvatarURL != url {
+                pending[token] = url
+            }
         }
 
-        for (token, url) in values where mentionAvatarTasks[token] == nil {
+        for (token, url) in pending where mentionAvatarTasks[token] == nil {
+            if let image = MentionAvatarImageStore.shared.cachedImage(for: url) {
+                applyMentionAvatar(image, url: url, token: token, in: textView)
+                continue
+            }
             mentionAvatarTasks[token] = Task { @MainActor [weak self, weak textView] in
                 let image = await MentionAvatarImageStore.shared.image(for: url)
                 guard let self else { return }
                 defer { self.mentionAvatarTasks[token] = nil }
                 guard !Task.isCancelled, let textView, let image else { return }
-                self.applyMentionAvatar(image, token: token, in: textView)
+                self.applyMentionAvatar(image, url: url, token: token, in: textView)
             }
+        }
+
+        for token in Array(mentionAvatarTasks.keys) where values[token] == nil {
+            mentionAvatarTasks[token]?.cancel()
+            mentionAvatarTasks[token] = nil
         }
     }
 
@@ -149,15 +165,24 @@ final class InlineAttachmentImageLoader {
         textView.needsDisplay = true
     }
 
-    private func applyMentionAvatar(_ image: NSImage, token: String, in textView: NSTextView) {
+    private func applyMentionAvatar(
+        _ image: NSImage,
+        url: URL,
+        token: String,
+        in textView: NSTextView
+    ) {
         guard let storage = textView.textStorage else { return }
         let range = NSRange(location: 0, length: storage.length)
+        var didApply = false
         storage.enumerateAttribute(.attachment, in: range) { value, _, _ in
             guard let attachment = value as? MentionTextAttachment,
-                  attachment.presentation.rawToken == token
+                  attachment.presentation.rawToken == token,
+                  attachment.appliedAvatarURL != url
             else { return }
-            attachment.updateImages(avatar: image)
+            attachment.updateImages(avatar: image, url: url)
+            didApply = true
         }
+        guard didApply else { return }
         textView.layoutManager?.invalidateDisplay(forCharacterRange: range)
         textView.needsDisplay = true
     }

--- a/App/Sources/SakuraCord/Views/ChannelSidebarView.swift
+++ b/App/Sources/SakuraCord/Views/ChannelSidebarView.swift
@@ -28,7 +28,7 @@ struct ChannelSidebarView: View {
                         addsTopSpacing: index == groups.startIndex,
                         rulesChannelID: guild?.rulesChannelID,
                         activeVoiceChannelID: activeVoiceChannelID,
-                        hiddenChannelIDs: hiddenChannelIDs,
+                        hiddenChannelIDs: voiceModel.hiddenChannelIDs,
                         voiceParticipantsByChannel: voiceSidebarParticipantsByChannel
                     )
                 }
@@ -62,10 +62,6 @@ struct ChannelSidebarView: View {
 
     private var separatorLineWidth: CGFloat {
         1 / max(displayScale, 1)
-    }
-
-    private var hiddenChannelIDs: Set<ChannelID> {
-        Set(channels.lazy.filter { voiceModel.conversationAccess(for: $0) == .hidden }.map(\.id))
     }
 
     private var voiceSidebarParticipantsByChannel: [ChannelID: [VoiceSidebarParticipant]] {

--- a/App/Sources/SakuraCord/Views/DiscordMessageContentView.swift
+++ b/App/Sources/SakuraCord/Views/DiscordMessageContentView.swift
@@ -100,12 +100,17 @@ struct MessageMentionResolver {
         self.message = message
     }
 
+    /// Resolves entirely from indexed stores.
+    ///
+    /// This previously scanned `model.messages` and `model.threadMessages`,
+    /// which was an O(messages) walk per mention per render and an observation
+    /// dependency on the timeline, so every new message re-rendered every
+    /// mention-bearing row. `messageAuthorsByID` preserves that fallback.
     func user(_ userID: UserID) -> User? {
         model.membersByID[userID]?.user
             ?? model.knownMentionMembers[userID]?.user
             ?? message?.mentionedUsers.first { $0.id == userID }
-            ?? model.messages.first { $0.author.id == userID }?.author
-            ?? model.threadMessages.first { $0.author.id == userID }?.author
+            ?? model.messageAuthorsByID[userID]
             ?? (model.snapshot?.currentUser.id == userID ? model.snapshot?.currentUser : nil)
     }
 
@@ -132,7 +137,7 @@ struct MessageMentionResolver {
             guard let roleID = RoleID(mention.id) else {
                 return MentionPresentation.fallback(for: mention)
             }
-            let role = model.guildRoles.first { $0.id == roleID }
+            let role = model.guildRolesByID[roleID]
                 ?? model.members.lazy.flatMap(\.roles).first { $0.id == roleID }
             return MentionPresentation(
                 rawToken: mention.rawToken,
@@ -183,8 +188,7 @@ struct MessageMentionResolver {
                     )
                 )
             }
-            let post = model.forumCataloguePosts.first { $0.id == channelID }
-                ?? model.forumPosts.first { $0.id == channelID }
+            let post = model.forumPost(withID: channelID)
             return MentionPresentation(
                 rawToken: mention.rawToken,
                 label: post?.thread.name ?? "unknown-post",
@@ -223,7 +227,7 @@ struct MessageMentionResolver {
     }
 
     private func channel(_ channelID: ChannelID) -> Channel? {
-        model.snapshot?.channels.first { $0.id == channelID }
+        model.channelsByID[channelID]
             ?? model.visibleChannels.first { $0.id == channelID }
     }
 
@@ -314,8 +318,7 @@ struct CustomEmojiRichText: View {
         case let .user(id):
             let user = model.membersByID[id]?.user
                 ?? model.knownMentionMembers[id]?.user
-                ?? model.messages.first { $0.author.id == id }?.author
-                ?? model.threadMessages.first { $0.author.id == id }?.author
+                ?? model.messageAuthorsByID[id]
                 ?? (model.snapshot?.currentUser.id == id ? model.snapshot?.currentUser : nil)
             guard let user else { return }
             model.showProfile(for: user)

--- a/App/Sources/SakuraCord/Views/MemberInspectorView.swift
+++ b/App/Sources/SakuraCord/Views/MemberInspectorView.swift
@@ -91,10 +91,44 @@ struct MemberSection: Identifiable, Equatable {
         return sections
     }
 
+    private struct MemberSortKey {
+        let key: String
+        let id: UInt64
+        let member: Member
+    }
+
+    /// Sorts by a folded key computed once per member.
+    ///
+    /// The previous implementation called `localizedStandardCompare` inside the
+    /// comparator, which runs a full locale-aware ICU collation on every one of
+    /// the O(n log n) comparisons. Discord re-sends the whole member list on
+    /// every presence change, so that dominated the main actor on large guilds.
+    /// Folding once per member trades exact locale collation for a case- and
+    /// diacritic-insensitive ordering, tie-broken by ID for stability.
     private static func sortedByName(_ members: [Member]) -> [Member] {
-        members.sorted {
-            $0.user.displayName.localizedStandardCompare($1.user.displayName) == .orderedAscending
+        var decorated: [MemberSortKey] = []
+        decorated.reserveCapacity(members.count)
+        for member in members {
+            decorated.append(
+                MemberSortKey(
+                    key: sortKey(for: member),
+                    id: member.id.rawValue,
+                    member: member
+                )
+            )
         }
+        decorated.sort { lhs, rhs in
+            if lhs.key != rhs.key { return lhs.key < rhs.key }
+            return lhs.id < rhs.id
+        }
+        return decorated.map(\.member)
+    }
+
+    private static func sortKey(for member: Member) -> String {
+        member.user.displayName.folding(
+            options: [.caseInsensitive, .diacriticInsensitive, .widthInsensitive],
+            locale: .current
+        )
     }
 }
 

--- a/App/Sources/SakuraCord/Views/MentionAttachmentRenderer.swift
+++ b/App/Sources/SakuraCord/Views/MentionAttachmentRenderer.swift
@@ -12,11 +12,15 @@ nonisolated final class MentionTextAttachment: NSTextAttachment {
     let font: NSFont
     private(set) var normalImage: NSImage
     private(set) var hoverImage: NSImage
+    /// The avatar already baked into `normalImage`/`hoverImage`, so a repeated
+    /// load does not re-rasterize and invalidate display for no visible change.
+    private(set) var appliedAvatarURL: URL?
 
     @MainActor
     init(presentation: MentionPresentation, font: NSFont, avatar: NSImage? = nil) {
         self.presentation = presentation
         self.font = font
+        appliedAvatarURL = avatar == nil ? nil : presentation.avatarURL
         normalImage = MentionAttachmentRenderer.image(
             presentation: presentation, font: font, avatar: avatar, hovered: false
         )
@@ -39,7 +43,7 @@ nonisolated final class MentionTextAttachment: NSTextAttachment {
     required init?(coder: NSCoder) { nil }
 
     @MainActor
-    func updateImages(avatar: NSImage?) {
+    func updateImages(avatar: NSImage?, url: URL? = nil) {
         normalImage = MentionAttachmentRenderer.image(
             presentation: presentation, font: font, avatar: avatar, hovered: false
         )
@@ -47,6 +51,7 @@ nonisolated final class MentionTextAttachment: NSTextAttachment {
             presentation: presentation, font: font, avatar: avatar, hovered: true
         )
         image = normalImage
+        appliedAvatarURL = url
     }
 }
 
@@ -72,7 +77,37 @@ enum MentionAttachmentRenderer {
         return value
     }
 
+    /// Rendered pills are cached because every rebuild of a message's
+    /// attributed string asks for two images per mention (normal and hover),
+    /// and each one is an off-screen rasterization.
+    private static let images = MentionPillImageCache()
+
     static func image(
+        presentation: MentionPresentation,
+        font: NSFont,
+        avatar: NSImage?,
+        hovered: Bool
+    ) -> NSImage {
+        let key = MentionPillImageCache.Key(
+            presentation: presentation,
+            fontSize: font.pointSize,
+            avatar: avatar,
+            hovered: hovered
+        )
+        if let cached = images.value(for: key) {
+            return cached
+        }
+        let value = render(
+            presentation: presentation,
+            font: font,
+            avatar: avatar,
+            hovered: hovered
+        )
+        images.insert(value, for: key)
+        return value
+    }
+
+    private static func render(
         presentation: MentionPresentation,
         font: NSFont,
         avatar: NSImage?,
@@ -176,6 +211,73 @@ enum MentionAttachmentRenderer {
             blue: CGFloat(hex & 0xff) / 255,
             alpha: 1
         )
+    }
+}
+
+@MainActor
+private final class MentionPillImageCache {
+    private let values = NSCache<Key, NSImage>()
+
+    init() {
+        values.countLimit = 2_000
+    }
+
+    typealias Key = MentionPillImageCacheKey
+
+    func value(for key: Key) -> NSImage? {
+        values.object(forKey: key)
+    }
+
+    func insert(_ value: NSImage, for key: Key) {
+        values.setObject(value, forKey: key)
+    }
+}
+
+nonisolated final class MentionPillImageCacheKey: NSObject {
+    private let label: String
+    private let colorHex: UInt32?
+    private let systemImage: String?
+    private let showsAvatar: Bool
+    private let avatar: ObjectIdentifier?
+    private let fontSize: CGFloat
+    private let hovered: Bool
+
+    init(
+        presentation: MentionPresentation,
+        fontSize: CGFloat,
+        avatar: NSImage?,
+        hovered: Bool
+    ) {
+        label = presentation.label
+        colorHex = presentation.colorHex
+        systemImage = presentation.systemImage
+        showsAvatar = if case .user = presentation.target { true } else { false }
+        self.avatar = avatar.map(ObjectIdentifier.init)
+        self.fontSize = fontSize
+        self.hovered = hovered
+    }
+
+    override var hash: Int {
+        var hasher = Hasher()
+        hasher.combine(label)
+        hasher.combine(colorHex)
+        hasher.combine(systemImage)
+        hasher.combine(showsAvatar)
+        hasher.combine(avatar)
+        hasher.combine(fontSize)
+        hasher.combine(hovered)
+        return hasher.finalize()
+    }
+
+    override func isEqual(_ object: Any?) -> Bool {
+        guard let other = object as? MentionPillImageCacheKey else { return false }
+        return label == other.label
+            && colorHex == other.colorHex
+            && systemImage == other.systemImage
+            && showsAvatar == other.showsAvatar
+            && avatar == other.avatar
+            && fontSize == other.fontSize
+            && hovered == other.hovered
     }
 }
 

--- a/App/Sources/SakuraCord/Views/MessageRowView.swift
+++ b/App/Sources/SakuraCord/Views/MessageRowView.swift
@@ -124,64 +124,23 @@ struct MessageRowView: View, Equatable {
             hasReplyPreview: replyPreview != nil,
             isEditing: isEditing
         )
-        VStack(alignment: .leading, spacing: 0) {
-            if let replyPreview {
-                MessageReplyContext(
-                    model: model,
-                    preview: replyPreview,
-                    isAvailable: isReplyAvailable,
-                    open: { openReply(replyPreview.messageID) }
-                )
-            }
-            if message.type == .chatInputCommand {
-                ApplicationCommandInvocationLine(model: model, message: message)
-            }
-            if message.type.hasGeneratedContent {
-                MessageContent(
-                    model: model,
-                    message: message,
-                    isEditing: $isEditing,
-                    editText: $editText,
-                    save: commitEdit,
-                    cancel: cancelEdit,
-                    react: react,
-                    isReactionPickerPresented: $isInlineReactionPickerPresented
-                )
-                .padding(.leading, 36)
-            } else {
-                HStack(alignment: .top, spacing: 12) {
-                    MessageAvatarColumn(
-                        model: model,
-                        startsGroup: startsGroup,
-                        author: authorPresentation.user,
-                        timestamp: message.timestamp
-                    )
-                    VStack(alignment: .leading, spacing: 4) {
-                        if startsGroup {
-                            MessageAuthorLine(
-                                model: model,
-                                message: message,
-                                author: authorPresentation.user,
-                                roleColorHex: authorPresentation.roleColorHex
-                            )
-                        }
-                        MessageContent(
-                            model: model,
-                            message: message,
-                            isEditing: $isEditing,
-                            editText: $editText,
-                            save: commitEdit,
-                            cancel: cancelEdit,
-                            react: react,
-                            isReactionPickerPresented: $isInlineReactionPickerPresented
-                        )
-                    }
-                }
-            }
-        }
-        .padding(.horizontal, 14)
-        .padding(.top, highlightInsets.top)
-        .padding(.bottom, highlightInsets.bottom)
+        MessageRowContent(
+            model: model,
+            message: message,
+            authorPresentation: authorPresentation,
+            startsGroup: startsGroup,
+            replyPreview: replyPreview,
+            isReplyAvailable: isReplyAvailable,
+            highlightInsets: highlightInsets,
+            isEditing: $isEditing,
+            editText: $editText,
+            save: commitEdit,
+            cancel: cancelEdit,
+            react: react,
+            openReply: openReply,
+            isReactionPickerPresented: $isInlineReactionPickerPresented
+        )
+        .equatable()
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(isHovering ? Color.primary.opacity(0.055) : .clear)
         .contentShape(Rectangle())
@@ -270,6 +229,101 @@ struct MessageRowView: View, Equatable {
         let value = "https://discord.com/channels/\(guild)/\(message.channelID)/\(message.id)"
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(value, forType: .string)
+    }
+}
+
+/// The expensive half of a message row, deliberately kept independent of hover.
+///
+/// `MessageRowView` re-evaluates its body on every pointer enter and exit,
+/// because the hover tint, action capsule, and `zIndex` all read that state.
+/// Wheel scrolling drags rows under a stationary pointer, so that fires
+/// continuously — and without this split it dragged the whole subtree with it,
+/// down to `SelectableMessageTextView.updateNSView`. Holding the content in a
+/// separate equatable view lets SwiftUI skip it when only hover changed.
+private struct MessageRowContent: View, Equatable {
+    let model: AppModel
+    let message: Message
+    let authorPresentation: MessageAuthorPresentation
+    let startsGroup: Bool
+    let replyPreview: MessageReplyPreview?
+    let isReplyAvailable: Bool
+    let highlightInsets: MessageRowHighlightInsets
+    @Binding var isEditing: Bool
+    @Binding var editText: String
+    let save: () -> Void
+    let cancel: () -> Void
+    let react: (String) -> Void
+    let openReply: (MessageID) -> Void
+    @Binding var isReactionPickerPresented: Bool
+
+    /// Compares the binding *values*, not the bindings, so an edit still
+    /// propagates while a hover change does not.
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.model === rhs.model
+            && lhs.message == rhs.message
+            && lhs.authorPresentation == rhs.authorPresentation
+            && lhs.startsGroup == rhs.startsGroup
+            && lhs.replyPreview == rhs.replyPreview
+            && lhs.isReplyAvailable == rhs.isReplyAvailable
+            && lhs.highlightInsets == rhs.highlightInsets
+            && lhs.isEditing == rhs.isEditing
+            && lhs.editText == rhs.editText
+            && lhs.isReactionPickerPresented == rhs.isReactionPickerPresented
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if let replyPreview {
+                MessageReplyContext(
+                    model: model,
+                    preview: replyPreview,
+                    isAvailable: isReplyAvailable,
+                    open: { openReply(replyPreview.messageID) }
+                )
+            }
+            if message.type == .chatInputCommand {
+                ApplicationCommandInvocationLine(model: model, message: message)
+            }
+            if message.type.hasGeneratedContent {
+                content.padding(.leading, 36)
+            } else {
+                HStack(alignment: .top, spacing: 12) {
+                    MessageAvatarColumn(
+                        model: model,
+                        startsGroup: startsGroup,
+                        author: authorPresentation.user,
+                        timestamp: message.timestamp
+                    )
+                    VStack(alignment: .leading, spacing: 4) {
+                        if startsGroup {
+                            MessageAuthorLine(
+                                model: model,
+                                message: message,
+                                author: authorPresentation.user,
+                                roleColorHex: authorPresentation.roleColorHex
+                            )
+                        }
+                        content
+                    }
+                }
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.top, highlightInsets.top)
+        .padding(.bottom, highlightInsets.bottom)
+    }
+
+    private var content: some View {
+        MessageContent(
+            model: model,
+            message: message,
+            isEditing: $isEditing,
+            editText: $editText,
+            save: save,
+            cancel: cancel,
+            react: react,
+            isReactionPickerPresented: $isReactionPickerPresented
+        )
     }
 }
 

--- a/App/Sources/SakuraCord/Views/MessageTimelineView.swift
+++ b/App/Sources/SakuraCord/Views/MessageTimelineView.swift
@@ -14,7 +14,15 @@ struct MessageTimelineView: View {
         ScrollViewReader { proxy in
             GeometryReader { geometry in
                 ScrollView {
-                    LazyVStack(alignment: .leading, spacing: 0) {
+                    // Not lazy: rows outside a lazy realization window trade
+                    // their measured height for an estimate, so the content
+                    // size oscillates by hundreds of points while scrolling and
+                    // the visible messages shift under the reader. Realizing
+                    // every row keeps the content size fixed. History only
+                    // grows 50 rows per explicit "Load earlier", never while
+                    // scrolling, so the cost is user-paced rather than per
+                    // frame.
+                    VStack(alignment: .leading, spacing: 0) {
                         if let channel = model.selectedChannel,
                            ConversationBeginningPolicy.showsBeginning(
                                isLoading: model.isLoadingMessages,

--- a/App/Sources/SakuraCord/Views/MessageTimelineView.swift
+++ b/App/Sources/SakuraCord/Views/MessageTimelineView.swift
@@ -105,13 +105,30 @@ struct MessageTimelineView: View {
                         loadEarlier(using: proxy)
                     }
                 }
+                .onScrollGeometryChange(for: ScrollDiagnosticsSample.self) { geometry in
+                    // Stays constant unless diagnostics are on, so the action
+                    // never fires in an ordinary run.
+                    ScrollDiagnostics.isEnabled
+                        ? ScrollDiagnosticsSample(
+                            contentHeight: geometry.contentSize.height,
+                            contentOffset: geometry.contentOffset.y
+                        )
+                        : ScrollDiagnosticsSample(contentHeight: 0, contentOffset: 0)
+                } action: { _, value in
+                    ScrollDiagnostics.recordGeometry(
+                        height: value.contentHeight,
+                        offset: value.contentOffset
+                    )
+                }
                 .onScrollPhaseChange { oldPhase, newPhase, context in
                     switch newPhase {
                     case .tracking, .interacting, .decelerating:
+                        ScrollDiagnostics.beginScroll(rowCount: model.messageRows.count)
                         scrollPolicy.userScrollBegan()
                     case .idle:
                         switch oldPhase {
                         case .tracking, .interacting, .decelerating:
+                            ScrollDiagnostics.endScroll()
                             let value = TimelineScrollState(geometry: context.geometry)
                             scrollPolicy.userScrollEnded(
                                 isNearBottom: value.isNearBottom

--- a/App/Sources/SakuraCord/Views/SelectableMessageTextView.swift
+++ b/App/Sources/SakuraCord/Views/SelectableMessageTextView.swift
@@ -147,6 +147,7 @@ struct SelectableMessageTextView: NSViewRepresentable {
     }
 
     func makeNSView(context: Context) -> RichMessageNSTextView {
+        ScrollDiagnostics.recordTextViewCreated()
         let textView = RichMessageNSTextView()
         textView.delegate = context.coordinator
         textView.isEditable = false
@@ -254,8 +255,10 @@ struct SelectableMessageTextView: NSViewRepresentable {
             width: width,
             minimumHeight: minimumHeight
         ) {
+            ScrollDiagnostics.recordHeightCacheHit()
             return cached
         }
+        ScrollDiagnostics.recordHeightCacheMiss()
         let value = RichMessageTextMeasurer.height(
             of: attributedValue(for: signature, textView: textView),
             width: width,
@@ -287,6 +290,7 @@ struct SelectableMessageTextView: NSViewRepresentable {
     }
 
     static func dismantleNSView(_ nsView: RichMessageNSTextView, coordinator: Coordinator) {
+        ScrollDiagnostics.recordTextViewDismantled()
         coordinator.cancelEmojiLoads()
         RichMessageSelectionOwnership.remove(nsView)
     }
@@ -460,6 +464,7 @@ private enum RichMessageAttributedText {
         emojiSize: CGFloat,
         mentionPresentations: [String: MentionPresentation]
     ) -> NSAttributedString {
+        ScrollDiagnostics.recordAttributedStringBuilt()
         let document = MessageDocumentCache.shared.document(for: source)
         var transformed = ""
         var tokens: [InlineToken] = []

--- a/App/Sources/SakuraCord/Views/SelectableMessageTextView.swift
+++ b/App/Sources/SakuraCord/Views/SelectableMessageTextView.swift
@@ -261,10 +261,56 @@ nonisolated enum RichMessageTextMeasurement {
     }
 }
 
-private struct RichMessageRenderSignature: Equatable {
+struct RichMessageRenderSignature: Equatable, Hashable {
     let source: String
     let emojiSize: CGFloat
     let mentionPresentations: [String: MentionPresentation]
+}
+
+/// Text layout results shared across rows.
+///
+/// `NSTextView` measurement used to live on the view instance, so a row that
+/// scrolled out of the `LazyVStack` and back re-ran TextKit layout from
+/// scratch inside SwiftUI's layout pass. Keying by signature and width lets a
+/// recycled row reuse the height it already computed.
+@MainActor
+enum RichMessageHeightCache {
+    private struct Key: Hashable {
+        let signature: RichMessageRenderSignature
+        let width: CGFloat
+        let minimumHeight: CGFloat
+    }
+
+    private static var values: [Key: CGFloat] = [:]
+    private static var insertionOrder: [Key] = []
+    private static let limit = 4_000
+
+    static func height(
+        signature: RichMessageRenderSignature?,
+        width: CGFloat,
+        minimumHeight: CGFloat
+    ) -> CGFloat? {
+        guard let signature else { return nil }
+        return values[Key(signature: signature, width: width, minimumHeight: minimumHeight)]
+    }
+
+    static func insert(
+        _ height: CGFloat,
+        signature: RichMessageRenderSignature?,
+        width: CGFloat,
+        minimumHeight: CGFloat
+    ) {
+        guard let signature else { return }
+        let key = Key(signature: signature, width: width, minimumHeight: minimumHeight)
+        guard values.updateValue(height, forKey: key) == nil else { return }
+        insertionOrder.append(key)
+        guard insertionOrder.count > limit else { return }
+        let evictionCount = limit / 4
+        for key in insertionOrder.prefix(evictionCount) {
+            values.removeValue(forKey: key)
+        }
+        insertionOrder.removeFirst(evictionCount)
+    }
 }
 
 @MainActor
@@ -404,15 +450,31 @@ final class RichMessageNSTextView: NSTextView {
 
     fileprivate func measuredSize(proposedWidth: CGFloat?, minimumHeight: CGFloat) -> CGSize {
         if let width = RichMessageTextMeasurement.constrainedWidth(proposedWidth) {
-            configureTextContainer(width: width)
             if let height = measuredHeights[width] {
+                configureTextContainer(width: width)
                 return CGSize(width: width, height: height)
             }
+            if let height = RichMessageHeightCache.height(
+                signature: renderSignature,
+                width: width,
+                minimumHeight: minimumHeight
+            ) {
+                configureTextContainer(width: width)
+                measuredHeights[width] = height
+                return CGSize(width: width, height: height)
+            }
+            configureTextContainer(width: width)
             let height = measuredHeight(minimumHeight: minimumHeight)
             if measuredHeights.count >= 4 {
                 measuredHeights.removeAll(keepingCapacity: true)
             }
             measuredHeights[width] = height
+            RichMessageHeightCache.insert(
+                height,
+                signature: renderSignature,
+                width: width,
+                minimumHeight: minimumHeight
+            )
             return CGSize(width: width, height: height)
         }
 

--- a/App/Sources/SakuraCord/Views/SelectableMessageTextView.swift
+++ b/App/Sources/SakuraCord/Views/SelectableMessageTextView.swift
@@ -158,8 +158,18 @@ struct SelectableMessageTextView: NSViewRepresentable {
         textView.textContainer?.heightTracksTextView = false
         textView.textContainer?.widthTracksTextView = true
         textView.textContainer?.lineBreakMode = .byWordWrapping
+        // Lay out unbounded vertically. `widthTracksTextView` keeps the width in
+        // sync with the frame SwiftUI assigns; nothing else sets this now that
+        // sizing no longer reaches into the displayed view.
+        textView.textContainer?.size = NSSize(
+            width: textView.bounds.width,
+            height: CGFloat.greatestFiniteMagnitude
+        )
         textView.isHorizontallyResizable = false
-        textView.isVerticallyResizable = true
+        // SwiftUI owns this view's height. Letting the text view resize itself
+        // to fit re-wrapped text lets its rendered height drift from the height
+        // SwiftUI measured, which the scroll view then has to correct.
+        textView.isVerticallyResizable = false
         textView.linkTextAttributes = [
             .foregroundColor: NSColor.linkColor,
             .underlineStyle: 0
@@ -183,7 +193,6 @@ struct SelectableMessageTextView: NSViewRepresentable {
             mentionPresentations: mentionPresentations
         )
         guard textView.renderSignature != signature else { return }
-        textView.invalidateMeasurementCache()
         textView.renderSignature = signature
         textView.textStorage?.setAttributedString(
             RichMessageAttributedText.make(
@@ -202,9 +211,78 @@ struct SelectableMessageTextView: NSViewRepresentable {
         nsView textView: RichMessageNSTextView,
         context: Context
     ) -> CGSize? {
-        textView.measuredSize(
-            proposedWidth: proposal.width,
-            minimumHeight: MessageRowLayoutMetrics.compactContentHeight
+        let minimumHeight = MessageRowLayoutMetrics.compactContentHeight
+        let signature = RichMessageRenderSignature(
+            source: source,
+            emojiSize: emojiSize,
+            mentionPresentations: mentionPresentations
+        )
+
+        if let width = RichMessageTextMeasurement.constrainedWidth(proposal.width) {
+            return CGSize(
+                width: width,
+                height: height(
+                    for: signature,
+                    textView: textView,
+                    width: width,
+                    minimumHeight: minimumHeight
+                )
+            )
+        }
+
+        let value = attributedValue(for: signature, textView: textView)
+        let width = RichMessageTextMeasurer.idealWidth(of: value)
+        return CGSize(
+            width: width,
+            height: height(
+                for: signature,
+                textView: textView,
+                width: width,
+                minimumHeight: minimumHeight
+            )
+        )
+    }
+
+    private func height(
+        for signature: RichMessageRenderSignature,
+        textView: RichMessageNSTextView,
+        width: CGFloat,
+        minimumHeight: CGFloat
+    ) -> CGFloat {
+        if let cached = RichMessageHeightCache.height(
+            signature: signature,
+            width: width,
+            minimumHeight: minimumHeight
+        ) {
+            return cached
+        }
+        let value = RichMessageTextMeasurer.height(
+            of: attributedValue(for: signature, textView: textView),
+            width: width,
+            minimumHeight: minimumHeight
+        )
+        RichMessageHeightCache.insert(
+            value,
+            signature: signature,
+            width: width,
+            minimumHeight: minimumHeight
+        )
+        return value
+    }
+
+    /// Reuses the text view's own storage when it already matches, so a plain
+    /// re-measure does not rebuild attachments.
+    private func attributedValue(
+        for signature: RichMessageRenderSignature,
+        textView: RichMessageNSTextView
+    ) -> NSAttributedString {
+        if textView.renderSignature == signature, let storage = textView.textStorage {
+            return storage
+        }
+        return RichMessageAttributedText.make(
+            source: source,
+            emojiSize: emojiSize,
+            mentionPresentations: mentionPresentations
         )
     }
 
@@ -310,6 +388,63 @@ enum RichMessageHeightCache {
             values.removeValue(forKey: key)
         }
         insertionOrder.removeFirst(evictionCount)
+    }
+}
+
+/// Measures message text without touching any displayed view.
+///
+/// Sizing used to run against the live `NSTextView`, mutating its frame and
+/// text container mid-query. Combined with `widthTracksTextView`, the width the
+/// text actually wrapped at could differ from the width it was measured at, so
+/// a row's rendered height drifted from the height SwiftUI was told — which the
+/// scroll view then corrected, over and over, as rows were realized.
+@MainActor
+enum RichMessageTextMeasurer {
+    private static let storage = NSTextStorage()
+    private static let layoutManager = NSLayoutManager()
+    private static let container = NSTextContainer(
+        size: CGSize(width: 1, height: CGFloat.greatestFiniteMagnitude)
+    )
+    private static var isConfigured = false
+
+    private static func prepare(_ value: NSAttributedString, width: CGFloat) {
+        if !isConfigured {
+            isConfigured = true
+            container.lineFragmentPadding = 0
+            container.widthTracksTextView = false
+            container.heightTracksTextView = false
+            container.lineBreakMode = NSLineBreakMode.byWordWrapping
+            layoutManager.addTextContainer(container)
+            storage.addLayoutManager(layoutManager)
+        }
+        storage.setAttributedString(value)
+        container.size = CGSize(width: max(1, width), height: .greatestFiniteMagnitude)
+        layoutManager.ensureLayout(for: container)
+    }
+
+    static func height(
+        of value: NSAttributedString,
+        width: CGFloat,
+        minimumHeight: CGFloat
+    ) -> CGFloat {
+        prepare(value, width: width)
+        return max(minimumHeight, ceil(layoutManager.usedRect(for: container).height))
+    }
+
+    /// The width the text would occupy laid out on a single unbounded line,
+    /// used when SwiftUI proposes no width.
+    static func idealWidth(of value: NSAttributedString) -> CGFloat {
+        prepare(value, width: RichMessageTextMeasurement.maximumWidth)
+        let glyphRange = layoutManager.glyphRange(for: container)
+        var usedBounds = CGRect.null
+        layoutManager.enumerateLineFragments(forGlyphRange: glyphRange) {
+            _, usedRect, _, lineGlyphRange, _ in
+            guard lineGlyphRange.length > 0 else { return }
+            usedBounds = usedBounds.union(usedRect)
+        }
+        return RichMessageTextMeasurement.constrainedWidth(
+            ceil(usedBounds.isNull ? 0 : usedBounds.maxX)
+        ) ?? 1
     }
 }
 
@@ -440,90 +575,6 @@ final class RichMessageNSTextView: NSTextView {
     var onURLClick: (URL) -> Bool = { _ in false }
     private var hoveredMentionLocation: Int?
     private var mentionTrackingArea: NSTrackingArea?
-    private var unconstrainedMeasurement: CGSize?
-    private var measuredHeights: [CGFloat: CGFloat] = [:]
-
-    fileprivate func invalidateMeasurementCache() {
-        unconstrainedMeasurement = nil
-        measuredHeights.removeAll(keepingCapacity: true)
-    }
-
-    fileprivate func measuredSize(proposedWidth: CGFloat?, minimumHeight: CGFloat) -> CGSize {
-        if let width = RichMessageTextMeasurement.constrainedWidth(proposedWidth) {
-            if let height = measuredHeights[width] {
-                configureTextContainer(width: width)
-                return CGSize(width: width, height: height)
-            }
-            if let height = RichMessageHeightCache.height(
-                signature: renderSignature,
-                width: width,
-                minimumHeight: minimumHeight
-            ) {
-                configureTextContainer(width: width)
-                measuredHeights[width] = height
-                return CGSize(width: width, height: height)
-            }
-            configureTextContainer(width: width)
-            let height = measuredHeight(minimumHeight: minimumHeight)
-            if measuredHeights.count >= 4 {
-                measuredHeights.removeAll(keepingCapacity: true)
-            }
-            measuredHeights[width] = height
-            RichMessageHeightCache.insert(
-                height,
-                signature: renderSignature,
-                width: width,
-                minimumHeight: minimumHeight
-            )
-            return CGSize(width: width, height: height)
-        }
-
-        if let unconstrainedMeasurement {
-            return unconstrainedMeasurement
-        }
-        configureTextContainer(width: RichMessageTextMeasurement.maximumWidth)
-        guard let layoutManager, let textContainer else {
-            let value = CGSize(width: 1, height: minimumHeight)
-            unconstrainedMeasurement = value
-            return value
-        }
-        let tracksTextViewWidth = textContainer.widthTracksTextView
-        textContainer.widthTracksTextView = false
-        textContainer.containerSize = NSSize(
-            width: RichMessageTextMeasurement.maximumWidth,
-            height: CGFloat.greatestFiniteMagnitude
-        )
-        layoutManager.ensureLayout(for: textContainer)
-        let glyphRange = layoutManager.glyphRange(for: textContainer)
-        var usedBounds = CGRect.null
-        layoutManager.enumerateLineFragments(forGlyphRange: glyphRange) {
-            _, usedRect, _, lineGlyphRange, _ in
-            guard lineGlyphRange.length > 0 else { return }
-            usedBounds = usedBounds.union(usedRect)
-        }
-        let width = RichMessageTextMeasurement.constrainedWidth(
-            ceil(usedBounds.isNull ? 0 : usedBounds.maxX)
-        ) ?? 1
-        textContainer.widthTracksTextView = tracksTextViewWidth
-        configureTextContainer(width: width)
-        let value = CGSize(width: width, height: measuredHeight(minimumHeight: minimumHeight))
-        unconstrainedMeasurement = value
-        return value
-    }
-
-    private func configureTextContainer(width: CGFloat) {
-        frame.size.width = width
-        textContainer?.containerSize = NSSize(
-            width: width,
-            height: .greatestFiniteMagnitude
-        )
-    }
-
-    private func measuredHeight(minimumHeight: CGFloat) -> CGFloat {
-        guard let layoutManager, let textContainer else { return minimumHeight }
-        layoutManager.ensureLayout(for: textContainer)
-        return max(minimumHeight, ceil(layoutManager.usedRect(for: textContainer).height))
-    }
 
     override func updateTrackingAreas() {
         super.updateTrackingAreas()

--- a/App/Tests/SakuraCordAppTests/AppModelTests.swift
+++ b/App/Tests/SakuraCordAppTests/AppModelTests.swift
@@ -1209,6 +1209,43 @@ private func eventuallyOnMain(_ condition: @escaping @MainActor () -> Bool) asyn
     #expect(await provider.requestCount(for: secondChannel) == 1)
 }
 
+/// The timeline realizes every loaded row, and `messageCache` used to retain
+/// every channel visited for the whole session. Eviction is only sound if the
+/// evicted channel reloads cleanly rather than showing a stale or empty page.
+@MainActor
+@Test func `visiting many channels evicts the least recently used history`() async throws {
+    let spares = AppModel.cachedChannelHistoryLimit
+    let provider = ChannelLoadTestProvider(spareChannels: spares)
+    let model = AppModel(launchMode: .offlineTesting, provider: provider)
+    await model.start()
+
+    let firstChannel = ChannelID(rawValue: 91001)
+    #expect(model.messages.map(\.channelID) == [firstChannel])
+
+    for index in 0 ..< spares {
+        model.selectedChannelID = provider.spareChannelID(index)
+        try await Task.sleep(for: .milliseconds(40))
+    }
+
+    // The most recent spare is still cached, so it restores synchronously.
+    let recent = provider.spareChannelID(spares - 1)
+    model.selectedChannelID = provider.spareChannelID(spares - 2)
+    try await Task.sleep(for: .milliseconds(40))
+    model.selectedChannelID = recent
+    #expect(model.messages.map(\.channelID) == [recent])
+    #expect(!model.isLoadingMessages)
+
+    // The first channel fell off the end and has to load again.
+    model.selectedChannelID = firstChannel
+    #expect(model.messages.isEmpty)
+    #expect(model.isLoadingMessages)
+
+    try await Task.sleep(for: .milliseconds(160))
+    #expect(model.messages.map(\.channelID) == [firstChannel])
+    #expect(!model.isLoadingMessages)
+    #expect(!model.hasMoreMessages)
+}
+
 @MainActor
 @Test func `app model reconciles lazy production reactors without repeated reads`() async throws {
     let provider = ChannelLoadTestProvider()
@@ -1284,16 +1321,28 @@ private func eventuallyOnMain(_ condition: @escaping @MainActor () -> Bool) asyn
 
 private actor ChannelLoadTestProvider: ChatProvider {
     private let user = User(id: UserID(rawValue: 91000), username: "tester", displayName: "Tester")
-    private let testChannels = [
-        Channel(id: ChannelID(rawValue: 91001), guildID: nil, name: "general"),
-        Channel(id: ChannelID(rawValue: 91002), guildID: nil, name: "other"),
-        Channel(
-            id: ChannelID(rawValue: 91003),
-            guildID: nil,
-            name: "Voice Room",
-            kind: .voice
-        ),
-    ]
+    private let testChannels: [Channel]
+
+    /// `spareChannels` are appended after the fixed three, so tests that depend
+    /// on the first channel being selected at startup are unaffected.
+    init(spareChannels: Int = 0) {
+        testChannels = [
+            Channel(id: ChannelID(rawValue: 91001), guildID: nil, name: "general"),
+            Channel(id: ChannelID(rawValue: 91002), guildID: nil, name: "other"),
+            Channel(
+                id: ChannelID(rawValue: 91003),
+                guildID: nil,
+                name: "Voice Room",
+                kind: .voice
+            ),
+        ] + (0 ..< spareChannels).map { index in
+            Channel(id: ChannelID(rawValue: 91100 + UInt64(index)), guildID: nil, name: "spare\(index)")
+        }
+    }
+
+    nonisolated func spareChannelID(_ index: Int) -> ChannelID {
+        ChannelID(rawValue: 91100 + UInt64(index))
+    }
     private var messageRequests: [ChannelID: Int] = [:]
     private var reactorRequests = 0
     private var activeReactorRequests = 0

--- a/App/Tests/SakuraCordAppTests/RichMessageMeasurementTests.swift
+++ b/App/Tests/SakuraCordAppTests/RichMessageMeasurementTests.swift
@@ -1,0 +1,68 @@
+import AppKit
+import Foundation
+@testable import SakuraCord
+import Testing
+
+@MainActor
+private func measured(_ value: String, width: CGFloat) -> CGFloat {
+    RichMessageTextMeasurer.height(
+        of: NSAttributedString(
+            string: value,
+            attributes: [.font: NSFont.systemFont(ofSize: 15)]
+        ),
+        width: width,
+        minimumHeight: MessageRowLayoutMetrics.compactContentHeight
+    )
+}
+
+@MainActor @Test func `message text measurement never returns less than a compact row`() {
+    #expect(measured("", width: 400) == MessageRowLayoutMetrics.compactContentHeight)
+    #expect(measured("hi", width: 400) >= MessageRowLayoutMetrics.compactContentHeight)
+}
+
+@MainActor @Test func `message text measurement grows with wrapped lines`() {
+    let single = measured("short", width: 400)
+    let wrapped = measured(String(repeating: "wrapping message content ", count: 40), width: 400)
+    #expect(wrapped > single * 3)
+}
+
+@MainActor @Test func `narrower width wraps to a taller measurement`() {
+    let content = String(repeating: "some conversational message text ", count: 8)
+    #expect(measured(content, width: 200) > measured(content, width: 600))
+}
+
+/// The row height cache is only sound if measuring is free of side effects.
+/// This previously ran against the displayed `NSTextView`, mutating its frame
+/// and text container, so repeated or interleaved queries could disagree.
+@MainActor @Test func `measurement is repeatable and order independent`() {
+    let first = String(repeating: "alpha beta gamma ", count: 12)
+    let second = String(repeating: "delta ", count: 3)
+
+    let firstAt300 = measured(first, width: 300)
+    let secondAt300 = measured(second, width: 300)
+
+    #expect(measured(first, width: 300) == firstAt300)
+    _ = measured(second, width: 500)
+    _ = measured(first, width: 120)
+    #expect(measured(first, width: 300) == firstAt300)
+    #expect(measured(second, width: 300) == secondAt300)
+}
+
+@MainActor @Test func `ideal width collapses content onto one unbounded line`() {
+    let content = String(repeating: "measure me ", count: 20)
+    let value = NSAttributedString(
+        string: content,
+        attributes: [.font: NSFont.systemFont(ofSize: 15)]
+    )
+    let idealWidth = RichMessageTextMeasurer.idealWidth(of: value)
+
+    #expect(idealWidth > 400)
+    #expect(idealWidth <= RichMessageTextMeasurement.maximumWidth)
+
+    let height = RichMessageTextMeasurer.height(
+        of: value,
+        width: idealWidth,
+        minimumHeight: MessageRowLayoutMetrics.compactContentHeight
+    )
+    #expect(height < measured(content, width: 200))
+}


### PR DESCRIPTION
## Summary

- Stops presence traffic (`PRESENCE_UPDATE` bursts, which arrive as a full member list per change) from re-deriving member sections and re-laying out the UI on every event; coalesces them into one update instead.
- Fixes message row heights drifting during scroll by making `SelectableMessageTextView`'s text measurement pure (it previously mutated the live, displayed `NSTextView` as a side effect of sizing).
- Adds opt-in scroll diagnostics (`--scroll-diagnostics`) that log counts and timings for text view creation, height-cache hits/misses, and content-height vs. scroll-offset deltas — used to diagnose the jitter below rather than guess at it.
- Fixes the reported scroll jitter: `LazyVStack` was substituting an estimate for the height of rows outside its realization window, so total content size oscillated by up to ~280pt during a single scroll, which the scrollbar and visible content both had to absorb. No scroll anchor can fix this in general, since the correct anchor depends on whether the change happened above or below the viewport. Switched to a plain `VStack`, which realizes every row and keeps content size stable by construction; confirmed via diagnostics.
- Stops hovering a message row from re-evaluating the entire row body (including the underlying `NSTextView`) by isolating hover state into a separate equatable child view.
- Bounds the per-channel message cache to the 12 most recently visited channels instead of retaining every channel's full history for the session.
- Adds `MainActorWorkDiagnostics`, opt-in timing around the main-actor state derivations (member sectioning, hidden-channel computation, message-row grouping, author presentation, gateway event handling) to measure whether any of them are worth offloading to a background thread before doing so. On the offline fixture, all five measure well under a 16.7ms frame budget.

## Why

Users reported random lag when loading new pages and scrolling, plus a distinct scrollbar/content jitter during scroll. Investigation and fixes were done in stages, each backed by measurement (Instruments trace + custom diagnostics) rather than by inference alone — two earlier hypotheses (impure text measurement as the jitter's sole cause, and row-realization cost) were tested and ruled out by the diagnostics before the actual cause (LazyVStack height estimation) was confirmed.

## Test plan

- [x] `./script/worktree_test.sh app` — 234 tests pass
- [x] `./script/build_and_run.sh package` — builds and packages cleanly
- [x] Manual scroll testing with `--offline-long-server-list --scroll-diagnostics`, confirming `contentHeightChanges` stays near zero and the reported jitter is gone
- [ ] Verify against a real large guild (member/channel count) that the main-actor diagnostics numbers hold before deciding whether to offload any derivation to a background thread (tracked as follow-up)