### PR TITLE
ci: speed up release packaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,20 @@ jobs:
           xcodebuild -version
           swift --version
           xcrun --sdk macosx --show-sdk-version
+      - name: Cache SwiftPM dependencies
+        if: github.event_name != 'workflow_dispatch' && !(github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+        uses: actions/cache@v4
+        with:
+          path: .codex-runtime/swiftpm-cache
+          key: swiftpm-${{ runner.os }}-${{ runner.arch }}-xcode-27-${{ hashFiles('App/Package.resolved', 'App/Package.swift', 'Packages/**/Package.swift') }}
+          restore-keys: |
+            swiftpm-${{ runner.os }}-${{ runner.arch }}-xcode-27-
       - name: Build
+        if: github.event_name != 'workflow_dispatch' && !(github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
         run: ./script/ci.sh
+      - name: Validate release sources
+        if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+        run: ./script/ci.sh checks
 
   release:
     if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || github.event_name == 'workflow_dispatch'
@@ -40,6 +52,13 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+      - name: Restore SwiftPM dependencies
+        uses: actions/cache/restore@v4
+        with:
+          path: .codex-runtime/swiftpm-cache
+          key: swiftpm-${{ runner.os }}-${{ runner.arch }}-xcode-27-${{ hashFiles('App/Package.resolved', 'App/Package.swift', 'Packages/**/Package.swift') }}
+          restore-keys: |
+            swiftpm-${{ runner.os }}-${{ runner.arch }}-xcode-27-
       - name: Check out current release-control files
         if: github.event_name == 'workflow_dispatch'
         uses: actions/checkout@v6

--- a/script/build_and_run.sh
+++ b/script/build_and_run.sh
@@ -79,7 +79,7 @@ if [[ "$UPDATES_ENABLED" == "1" ]]; then
 fi
 BUILD_FLAGS=()
 if [[ "$MODE" == "package-release" ]]; then
-  BUILD_FLAGS=(-c release)
+  BUILD_FLAGS=(-c release --disable-index-store)
 fi
 APP_ICON_NAME="$SAKURACORD_PRODUCT_NAME"
 APP_ICON_SOURCE="${SAKURACORD_APP_ICON:-SakuraCord.icon}"

--- a/script/ci.sh
+++ b/script/ci.sh
@@ -2,6 +2,17 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=worktree_runtime.sh
+source "$ROOT_DIR/script/worktree_runtime.sh"
+
+MODE="${1:-all}"
+case "$MODE" in
+  all|checks) ;;
+  *)
+    echo "usage: $0 [all|checks]" >&2
+    exit 2
+    ;;
+esac
 
 "$ROOT_DIR/script/code_quality.sh" check
 "$ROOT_DIR/script/test_release_metadata.sh"
@@ -10,9 +21,9 @@ node --test "$ROOT_DIR/script/release_automation.test.mjs"
 
 CREDENTIAL_PATTERN='(Authorization:[[:space:]]*(Bot|Bearer)?[[:space:]]*[A-Za-z0-9._-]{24,}|mfa\.[A-Za-z0-9_-]{20,})'
 if command -v rg >/dev/null 2>&1; then
-  CREDENTIAL_SCAN=(rg -n --hidden -g '!README.md' -g '!script/ci.sh' -g '!.git/**' -g '!.build/**')
+  CREDENTIAL_SCAN=(rg -n --hidden -g '!README.md' -g '!script/ci.sh' -g '!.git/**' -g '!.build/**' -g '!.codex-runtime/**')
 else
-  CREDENTIAL_SCAN=(grep -REnI --exclude=README.md --exclude=ci.sh --exclude-dir=.git --exclude-dir=.build)
+  CREDENTIAL_SCAN=(grep -REnI --exclude=README.md --exclude=ci.sh --exclude-dir=.git --exclude-dir=.build --exclude-dir=.codex-runtime)
 fi
 
 if "${CREDENTIAL_SCAN[@]}" "$CREDENTIAL_PATTERN" "$ROOT_DIR"; then
@@ -20,8 +31,16 @@ if "${CREDENTIAL_SCAN[@]}" "$CREDENTIAL_PATTERN" "$ROOT_DIR"; then
   exit 1
 fi
 
+if [[ "$MODE" == "checks" ]]; then
+  exit 0
+fi
+
 for attempt in 1 2 3; do
-  if swift package --package-path "$ROOT_DIR/App" resolve; then
+  if swift package \
+    --package-path "$SAKURACORD_PACKAGE_DIR" \
+    --cache-path "$SAKURACORD_SWIFTPM_CACHE_DIR" \
+    --scratch-path "$SAKURACORD_SCRATCH_DIR" \
+    resolve; then
     break
   fi
   if [[ "$attempt" -eq 3 ]]; then
@@ -32,4 +51,8 @@ for attempt in 1 2 3; do
   sleep $((attempt * 5))
 done
 
-swift build --package-path "$ROOT_DIR/App" --product SakuraCord
+swift build \
+  --package-path "$SAKURACORD_PACKAGE_DIR" \
+  --cache-path "$SAKURACORD_SWIFTPM_CACHE_DIR" \
+  --scratch-path "$SAKURACORD_SCRATCH_DIR" \
+  --product SakuraCord


### PR DESCRIPTION
## What changed

- run the existing static and release checks without performing a redundant debug build for tag and manual release runs
- persist the dedicated SwiftPM dependency cache on normal trusted builds and restore it for release packaging
- disable index-store generation for optimized release builds

## Why

The `Package DMG` step includes a fresh optimized Swift build on a separate runner. That build dominates release time, while the actual app assembly, DMG creation, signing, and verification are comparatively small. The earlier CI job also performed a debug build whose products cannot be reused by the release build.

These changes remove that redundant compilation and reuse dependency downloads while preserving the existing release build, signing, appcast, publication, and DMG verification behavior. They do not change application code or Discord announcement behavior.

## Validation

- `./script/ci.sh`
- `./script/code_quality.sh check`
- `bash -n script/ci.sh script/build_and_run.sh`
- parsed `.github/workflows/ci.yml` with Ruby YAML
- `git diff --check upstream/main..HEAD`
